### PR TITLE
Replace _countof with custom macro

### DIFF
--- a/tests/base_test.h
+++ b/tests/base_test.h
@@ -1,5 +1,7 @@
 /* This files stores common datastructures and functions required to run test using each of the benchmarks */
 
+#define COUNTOF(array) (sizeof(array) / sizeof(array[0]))
+
 typedef struct options
 {
   bool verbose;

--- a/tests/microply_test.cpp
+++ b/tests/microply_test.cpp
@@ -53,11 +53,11 @@ read_ply( const char* filename, TriMesh* mesh, bool *is_binary )
 		{ PLY_PROP_POSITION_X,  ply_prop_decimal, sizeof(float), 0,  &fzero },
 		{ PLY_PROP_POSITION_Y,  ply_prop_decimal, sizeof(float), 4,  &fzero },
 		{ PLY_PROP_POSITION_Z,  ply_prop_decimal, sizeof(float), 8,  &fzero } };
-  ply_convert(&file, PLY_ELEMENT_VERTICES, map_verts, _countof(map_verts), sizeof(Vec3f), (void **)&mesh->vertices, &mesh->n_verts);
+  ply_convert(&file, PLY_ELEMENT_VERTICES, map_verts, COUNTOF(map_verts), sizeof(Vec3f), (void **)&mesh->vertices, &mesh->n_verts);
 
 	uint32_t  izero = 0;
 	ply_map_t map_inds[] = { { PLY_PROP_INDICES, ply_prop_uint, sizeof(uint32_t), 0, &izero } };
-	ply_convert(&file, PLY_ELEMENT_FACES, map_inds, _countof(map_inds), sizeof(uint32_t), (void **)&mesh->faces, &mesh->n_faces);
+	ply_convert(&file, PLY_ELEMENT_FACES, map_inds, COUNTOF(map_inds), sizeof(uint32_t), (void **)&mesh->faces, &mesh->n_faces);
   mesh->n_faces /= 3;
   
 	// You gotta free the memory manually!


### PR DESCRIPTION
Instead of depending on the MSVC's specific `_countof` macro to
determine the number of elements in an array, define `COUNTOF` and use
that instead to improve portability.